### PR TITLE
chore: change current-status parameter to success parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ YOUR_SLACK_WEBHOOK: Webhook URL from Slack Incoming Webhook application
 ```yaml
 - uses: reside-eng/workflow-status-slack-notification@v1
   with:
-    # Status of the current run
+    # Workflow success
     #
-    # Default: failure
+    # Default: false
     # Required: true
-    current-status: ''
+    success: ''
 
     # Webhook URL with token for notifications
     #
@@ -74,9 +74,9 @@ jobs:
 
       # Your steps...
 
-  success-notification:
-    if: success()
-    name: success-notification
+  status-notification:
+    if: always()
+    name: status-notification
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -85,24 +85,9 @@ jobs:
 
       - uses: reside-eng/workflow-status-slack-notification@v1.0.7
         with:
-          current-status: "success"
-          slack-webhook: "${{ secrets.YOUR_SLACK_WEBHOOK }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  failure-notification:
-    if: failure()
-    name: failure-notification
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2.3.4
-
-      - uses: reside-eng/workflow-status-slack-notification@v1.0.7
-        with:
-          current-status: "failure"
-          slack-webhook: "${{ secrets.YOUR_SLACK_WEBHOOK }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          success: ${{ success() }}
+          slack-webhook: ${{ secrets.YOUR_SLACK_WEBHOOK }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 # Local development

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: 'Workflow Status Slack Notification'
 description: 'Notify uppon workflow failure/success'
 inputs:
-  current-status:
-    description: 'Status of the current run'
+  success:
+    description: 'Workflow success'
     required: true
-    default: 'failure'
+    default: 'false'
   slack-webhook:
     description: 'Webhook URL with token for notifications'
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -69288,7 +69288,7 @@ var external_url_ = __nccwpck_require__(8835);
 
 var Inputs;
 (function (Inputs) {
-    Inputs["CurrentStatus"] = "current-status";
+    Inputs["Success"] = "success";
     Inputs["SlackWebhook"] = "slack-webhook";
     Inputs["GithubToken"] = "github-token";
 })(Inputs || (Inputs = {}));
@@ -69434,14 +69434,15 @@ function handleError(err) {
  */
 async function pipeline() {
     const lastStatus = await getLastRunStatus();
-    const currentStatus = core.getInput(Inputs.CurrentStatus);
+    const success = core.getInput(Inputs.Success);
     const webhookUrl = core.getInput(Inputs.SlackWebhook);
-    core.info(`Last run status: ${lastStatus}`);
-    core.info(`Current run status: ${currentStatus}`);
-    if (currentStatus !== 'success' && currentStatus !== 'failure') {
-        core.setFailed('Wrong current status value');
+    if (success !== 'true' && success !== 'false') {
+        core.setFailed('Wrong success value');
         return;
     }
+    const currentStatus = success === 'true' ? 'success' : 'failure';
+    core.info(`Last run status: ${lastStatus}`);
+    core.info(`Current run status: ${currentStatus}`);
     let url;
     try {
         url = new external_url_.URL(webhookUrl);

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -49,7 +49,7 @@ function setupMock() {
   mock = {
     // Default action inputs
     inputs: {
-      'current-status': 'success',
+      success: 'true',
       'slack-webhook': `${slackUrl}${slackPath}`,
       'github-token': `${process.env.GITHUB_TOKEN}`,
     },
@@ -184,7 +184,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
   });
 
   it('should send failure notification if last run succeeded and current fails', async () => {
-    mock.inputs['current-status'] = 'failure';
+    mock.inputs.success = 'false';
 
     await run();
 
@@ -236,7 +236,7 @@ describe('last run status retrieved from cache (re-run workflow behavior)', () =
   });
 
   it('should not send notification if last run failed and current fails', async () => {
-    mock.inputs['current-status'] = 'failure';
+    mock.inputs.success = 'false';
 
     await run();
 
@@ -362,7 +362,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
 
   it('should send failure notification if last run succeeded and current fails', async () => {
     context.workflow = 'Success workflow (for test purpose only)';
-    mock.inputs['current-status'] = 'failure';
+    mock.inputs.success = 'false';
 
     await run();
 
@@ -413,7 +413,7 @@ describe('last run status retrieved from GH CLI (new commit workflow behavior)',
   });
 
   it('should not send notification if last run failed and current fails', async () => {
-    mock.inputs['current-status'] = 'failure';
+    mock.inputs.success = 'false';
 
     await run();
 
@@ -488,7 +488,7 @@ describe('inputs format', () => {
   });
 
   it('should fail with wrong current status value', async () => {
-    mock.inputs['current-status'] = 'notgood';
+    mock.inputs.success = 'notgood';
     await run();
     expect(mockCore.setFailed).toHaveBeenCalledTimes(1);
     expect(mockFn).toBeCalledTimes(0);

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { exec, ExecOptions } from '@actions/exec';
 import { URL } from 'url';
 
 export enum Inputs {
-  CurrentStatus = 'current-status',
+  Success = 'success',
   SlackWebhook = 'slack-webhook',
   GithubToken = 'github-token',
 }
@@ -191,16 +191,18 @@ function handleError(err: Error): void {
  */
 async function pipeline() {
   const lastStatus = await getLastRunStatus();
-  const currentStatus = core.getInput(Inputs.CurrentStatus);
+  const success = core.getInput(Inputs.Success);
   const webhookUrl = core.getInput(Inputs.SlackWebhook);
+
+  if (success !== 'true' && success !== 'false') {
+    core.setFailed('Wrong success value');
+    return;
+  }
+
+  const currentStatus = success === 'true' ? 'success' : 'failure';
 
   core.info(`Last run status: ${lastStatus}`);
   core.info(`Current run status: ${currentStatus}`);
-
-  if (currentStatus !== 'success' && currentStatus !== 'failure') {
-    core.setFailed('Wrong current status value');
-    return;
-  }
 
   let url;
   try {


### PR DESCRIPTION
Change the `current-status` parameter to `success` parameter.

For ease of use in our workflows we'll specify if the current workflow status is a success or not instead of the status itself.